### PR TITLE
Add fns to stat output (isFile, etc)

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -2,6 +2,13 @@ const { HyperdriveOptions, DriveStats, MountStats, CoreStats } = require('./rpc/
 const { Stat, Mount } = require('./rpc/daemon/drive_pb.js')
 
 const CHUNK_SIZE = 3.9e6
+Stat.IFSOCK = 49152 // 0b1100...
+Stat.IFLNK = 40960 // 0b1010...
+Stat.IFREG = 32768 // 0b1000...
+Stat.IFBLK = 24576 // 0b0110...
+Stat.IFDIR = 16384 // 0b0100...
+Stat.IFCHR = 8192 // 0b0010...
+Stat.IFIFO = 4096 // 0b0001...
 
 function fromHyperdriveOptions (opts) {
   const extracted = {
@@ -59,6 +66,13 @@ function fromStat (stat) {
   }
 
   return {
+    isSocket: statModeCheck(Stat.IFSOCK),
+    isSymbolicLink: statModeCheck(Stat.IFLNK),
+    isFile: statModeCheck(Stat.IFREG),
+    isBlockDevice: statModeCheck(Stat.IFBLK),
+    isDirectory: statModeCheck(Stat.IFDIR),
+    isCharacterDevice: statModeCheck(Stat.IFCHR),
+    isFIFO: statModeCheck(Stat.IFIFO),
     mode: stat.getMode(),
     uid: stat.getUid(),
     gid: stat.getGid(),
@@ -68,6 +82,12 @@ function fromStat (stat) {
     linkname: stat.getLinkname(),
     mount: fromMount(stat.getMount()),
     metadata
+  }
+}
+
+function statModeCheck (mask) {
+  return function () {
+    return (mask & this.mode) === mask
   }
 }
 


### PR DESCRIPTION
Adds common methods to the output of the stat() call:

- isSocket
- isSymbolicLink
- isFile
- isBlockDevice
- isDirectory
- isCharacterDevice
- isFIFO

These functions were included in the output of hyperdrive's stat() call and I've got some code that depends on it. If you don't think this should be added I can find a way around it, but I thought I'd try this first.