### PR TITLE
Fix stat metadata encoding

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -87,7 +87,9 @@ function toStat (statOpts) {
   if (statOpts.metadata) {
     const metadataMap = stat.getMetadataMap()
     for (let key of Object.keys(statOpts.metadata)) {
-      metadataMap.set(key, new Buffer(statOpts.metadata[key], 'utf8'))
+      if (statOpts.metdata[key]) { 
+        metadataMap.set(key, new Buffer(statOpts.metadata[key], 'utf8'))
+      }
     }
   }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -51,11 +51,11 @@ function toMount (mountOpts) {
 
 function fromStat (stat) {
   const metadataMap = stat.getMetadataMap()
-  if (metadataMap) {
+  if (metadataMap.getLength()) {
     var metadata = {}
-    for (let key of Object.keys(stat.getMetadataMap())) {
-      metadata[key] = metadataMap.get(key)
-    }
+    metadataMap.forEach((value, key) => {
+      metadata[key] = new Buffer(value).toString('utf8')
+    })
   }
 
   return {
@@ -87,7 +87,7 @@ function toStat (statOpts) {
   if (statOpts.metadata) {
     const metadataMap = stat.getMetadataMap()
     for (let key of Object.keys(statOpts.metadata)) {
-      metadataMap.set(key, statOpts[key])
+      metadataMap.set(key, new Buffer(statOpts.metadata[key], 'utf8'))
     }
   }
 


### PR DESCRIPTION
This fixes two issues:

 1. Fixes the extraction of metadata values from the grpc `Map` API (which is weird AF)
 2. Encodes the metadata KVs in UTF8